### PR TITLE
Perhaps having the requirement on the earlier job stops the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,6 @@ workflows:
         jobs:
             - build
             - deploy:
-                requires:
-                    - build
                 filters:
                     branches:
                         only: master


### PR DESCRIPTION
According to CircleCI support what was in the last PR should have worked for triggering builds on releases. It dawned on me that perhaps we need to remove the build step dependencies to make it work, or the tag based filtering needs to be deployed the whole way down the workflow tree.